### PR TITLE
add network connected notification hook and guard xposed hooks with android sdk version checks

### DIFF
--- a/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/DoNotAutoOpenCaptivePortalHook.kt
+++ b/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/DoNotAutoOpenCaptivePortalHook.kt
@@ -1,5 +1,6 @@
 package de.binarynoise.captiveportalautologin.xposed
 
+import android.os.Build
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedHelpers
@@ -7,6 +8,10 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage
 
 class DoNotAutoOpenCaptivePortalHook : IXposedHookLoadPackage {
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
+        if (lpparam.packageName == "com.android.systemui" && Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM)
+            return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
+            return
         val StandardWifiEntryClass = XposedHelpers.findClass("com.android.wifitrackerlib.StandardWifiEntry", lpparam.classLoader)
         val ConnectCallbackClass = XposedHelpers.findClass("com.android.wifitrackerlib.WifiEntry\$ConnectCallback", lpparam.classLoader)
         XposedHelpers.findAndHookMethod(StandardWifiEntryClass, "connect", ConnectCallbackClass, object : XC_MethodHook() {

--- a/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/LocationIndicatorHook.kt
+++ b/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/LocationIndicatorHook.kt
@@ -1,5 +1,6 @@
 package de.binarynoise.captiveportalautologin.xposed
 
+import android.os.Build
 import de.binarynoise.captiveportalautologin.BuildConfig
 import de.binarynoise.liberator.cast
 import de.robv.android.xposed.IXposedHookLoadPackage
@@ -7,9 +8,10 @@ import de.robv.android.xposed.XposedHelpers
 import de.robv.android.xposed.callbacks.XC_LoadPackage
 import de.robv.android.xposed.XC_MethodHook as MethodHook
 
-
 class LocationIndicatorHook : IXposedHookLoadPackage {
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S)
+            return
         XposedHelpers.findAndHookMethod(
             "com.android.systemui.appops.AppOpsControllerImpl", lpparam.classLoader, "getActiveAppOps", Boolean::class.java,
             object : MethodHook() {

--- a/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/NetworkConnectedHook.kt
+++ b/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/NetworkConnectedHook.kt
@@ -1,0 +1,25 @@
+package de.binarynoise.captiveportalautologin.xposed
+
+import android.net.Network
+import de.robv.android.xposed.IXposedHookLoadPackage
+import de.robv.android.xposed.XC_MethodReplacement
+import de.robv.android.xposed.XposedHelpers
+import de.robv.android.xposed.callbacks.XC_LoadPackage
+import de.robv.android.xposed.XC_MethodHook as MethodHook
+
+class NetworkConnectedHook : IXposedHookLoadPackage {
+    override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
+        val NetworkStackNotifierClass = XposedHelpers.findClass("com.android.networkstack.NetworkStackNotifier", lpparam.classLoader)
+        XposedHelpers.findAndHookMethod(NetworkStackNotifierClass, "isVenueInfoNotificationEnabled", XC_MethodReplacement.returnConstant(false))
+        XposedHelpers.findAndHookMethod(NetworkStackNotifierClass, "updateNotifications", Network::class.java, object: MethodHook() {
+            override fun beforeHookedMethod(param: MethodHookParam) {
+                val network = param.args[0] as Network
+                val mNetworkStatus = XposedHelpers.getObjectField(param.thisObject, "mNetworkStatus")
+                val trackedNetworkStatus = XposedHelpers.callMethod(mNetworkStatus, "get", network)
+                if (trackedNetworkStatus == null)
+                    return
+                XposedHelpers.setBooleanField(trackedNetworkStatus, "mValidatedNotificationPending", false)
+            }
+        })
+    }
+}

--- a/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/NetworkConnectedHook.kt
+++ b/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/NetworkConnectedHook.kt
@@ -1,6 +1,7 @@
 package de.binarynoise.captiveportalautologin.xposed
 
 import android.net.Network
+import android.os.Build
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodReplacement
 import de.robv.android.xposed.XposedHelpers
@@ -9,6 +10,8 @@ import de.robv.android.xposed.XC_MethodHook as MethodHook
 
 class NetworkConnectedHook : IXposedHookLoadPackage {
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
+            return
         val NetworkStackNotifierClass = XposedHelpers.findClass("com.android.networkstack.NetworkStackNotifier", lpparam.classLoader)
         XposedHelpers.findAndHookMethod(NetworkStackNotifierClass, "isVenueInfoNotificationEnabled", XC_MethodReplacement.returnConstant(false))
         XposedHelpers.findAndHookMethod(NetworkStackNotifierClass, "updateNotifications", Network::class.java, object: MethodHook() {

--- a/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/ReevaluationHook.kt
+++ b/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/ReevaluationHook.kt
@@ -7,6 +7,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import de.binarynoise.logger.Logger.log
@@ -16,9 +17,11 @@ import de.robv.android.xposed.XposedHelpers
 import de.robv.android.xposed.callbacks.XC_LoadPackage
 import de.robv.android.xposed.XC_MethodHook as MethodHook
 
-
 class ReevaluationHook : IXposedHookLoadPackage {
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S)
+            return
+        // TODO: find out if and where the ConnectivityManager was before S
         try {
             val ConnectivityManagerClass = Class.forName("android.net.ConnectivityManager", false, lpparam.classLoader)
             

--- a/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/XposedInit.kt
+++ b/app/src/main/kotlin/de/binarynoise/captiveportalautologin/xposed/XposedInit.kt
@@ -25,6 +25,7 @@ class XposedInit : IXposedHookLoadPackage {
                 LocationIndicatorHook().handleLoadPackage(lpparam)
                 DoNotAutoOpenCaptivePortalHook().handleLoadPackage(lpparam)
             }
+            "com.android.networkstack" -> NetworkConnectedHook().handleLoadPackage(lpparam)
             "com.android.settings" -> DoNotAutoOpenCaptivePortalHook().handleLoadPackage(lpparam)
             else -> log("${BuildConfig.APPLICATION_ID} doesn't know how to hook ${lpparam.packageName}")
         }

--- a/app/src/main/res/values/xposed.xml
+++ b/app/src/main/res/values/xposed.xml
@@ -12,5 +12,6 @@
         <item>com.android.server.telecom</item>
         <item>com.android.systemui</item>
         <item>com.android.settings</item>
+        <item>com.android.networkstack</item>
     </string-array>
 </resources>


### PR DESCRIPTION
* The `NetworkConnectedHook` removes the "`Connected`" and "`Connected / Tap to view website`" notifications shown after passing the portal