### PR TITLE
Potential fix for code scanning alert no. 1: Improper verification of intent by broadcast receiver

### DIFF
--- a/app/src/main/kotlin/de/binarynoise/captiveportalautologin/BootCompletedReceiver.kt
+++ b/app/src/main/kotlin/de/binarynoise/captiveportalautologin/BootCompletedReceiver.kt
@@ -1,14 +1,16 @@
 package de.binarynoise.captiveportalautologin
 
-import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import de.binarynoise.logger.Logger.log
 
 class BootCompletedReceiver : BroadcastReceiver() {
-    @SuppressLint("UnsafeProtectedBroadcastReceiver")
     override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) {
+            log("BootCompletedReceiver received unexpected intent: $intent")
+            return
+        }
         log("onReceive $intent")
         ConnectivityChangeListenerService.start(true)
     }


### PR DESCRIPTION
Potential fix for [https://github.com/binarynoise/CaptivePortalAutoLogin/security/code-scanning/1](https://github.com/binarynoise/CaptivePortalAutoLogin/security/code-scanning/1)

To fix the problem, the `onReceive` method of `BootCompletedReceiver` should check that the received intent's action is `Intent.ACTION_BOOT_COMPLETED` before executing any logic. This ensures that only the legitimate system broadcast will trigger the receiver's functionality. The check should be added at the start of the `onReceive` method, returning early if the action does not match. No additional imports are needed, as `Intent.ACTION_BOOT_COMPLETED` is available in the Android SDK. The fix should be applied in `app/src/main/kotlin/de/binarynoise/captiveportalautologin/BootCompletedReceiver.kt`, specifically in the `onReceive` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
