### PR TITLE
disable build cache

### DIFF
--- a/.github/workflows/android-build-debug.yml
+++ b/.github/workflows/android-build-debug.yml
@@ -9,24 +9,24 @@ jobs:
     runs-on: self-hosted
     
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-      
-    - name: Build ARM64 Debug APK
-      run: ./gradlew :app:assembleArm64Debug
-      
-    - name: Upload ARM64 Debug APK
-      uses: actions/upload-artifact@v4
-      with:
-        name: arm64-debug-apk
-        path: app/build/outputs/apk/arm64/debug/app-arm64-debug.apk
-        retention-days: 30
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build ARM64 Debug APK
+        run: ./gradlew :app:assembleArm64Debug
+
+      - name: Upload ARM64 Debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: arm64-debug-apk
+          path: app/build/outputs/apk/arm64/debug/app-arm64-debug.apk
+          retention-days: 30

--- a/.github/workflows/android-build-debug.yml
+++ b/.github/workflows/android-build-debug.yml
@@ -18,16 +18,6 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         
-    - name: Cache Gradle packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/*.gradle', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-          
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -9,24 +9,24 @@ jobs:
     runs-on: self-hosted
     
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-      
-    - name: Build Linux Shadow Jar
-      run: ./gradlew :linux:shadowJar
-      
-    - name: Upload ARM64 Debug APK
-      uses: actions/upload-artifact@v4
-      with:
-        name: linux-shadow-jar
-        path: linux/build/libs/linux-shadow.jar
-        retention-days: 30
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build Linux Shadow Jar
+        run: ./gradlew :linux:shadowJar
+
+      - name: Upload ARM64 Debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-shadow-jar
+          path: linux/build/libs/linux-shadow.jar
+          retention-days: 30

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -18,16 +18,6 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         
-    - name: Cache Gradle packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/*.gradle', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-          
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,34 +9,34 @@ jobs:
     runs-on: self-hosted
     
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-      
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-      
-    - name: Run unit tests
-      run: ./gradlew test
-      
-    - name: Run lint checks
-      run: ./gradlew lint
-      
-    - name: Run all verification checks
-      run: ./gradlew check
-      
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: test-results
-        path: |
-          **/build/reports/tests/**
-          **/build/reports/lint-results*.html
-          **/*.sarif
-        retention-days: 30
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Run lint checks
+        run: ./gradlew lint
+
+      - name: Run all verification checks
+        run: ./gradlew check
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: |
+            **/build/reports/tests/**
+            **/build/reports/lint-results*.html
+            **/*.sarif
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        
-    - name: Cache Gradle packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/*.gradle', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-          
+      
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       


### PR DESCRIPTION
this speeds up the CI by >1 min by skipping the download of 2.5GB per run